### PR TITLE
fix parsing of bogus-based character percent codes

### DIFF
--- a/src/smarteiffel/parser/eiffel_parser.e
+++ b/src/smarteiffel/parser/eiffel_parser.e
@@ -1810,6 +1810,10 @@ feature {}
                            error_handler.print_as_error
                         end
                         value := ascii_code.to_character
+                     else
+                        error_handler.add_position(current_position)
+                        error_handler.append(em38)
+                        error_handler.print_as_fatal_error
                      end
                   when '1' .. '9' then
                      ascii_code := cc.decimal_value

--- a/test/language/error_warning_msg/bad_character3.e
+++ b/test/language/error_warning_msg/bad_character3.e
@@ -1,0 +1,35 @@
+-- This file is part of SmartEiffel The GNU Eiffel Compiler Tools and Libraries.
+-- See the Copyright notice at the end of this file.
+--
+class BAD_CHARACTER3
+
+create {}
+   make
+
+feature {ANY}
+   make
+      local
+         c: CHARACTER
+      do
+         c := '%/0?FF/'
+      end
+
+end -- class BAD_CHARACTER1
+--
+-- ------------------------------------------------------------------------------------------------------------------------------
+-- Copyright notice below. Please read.
+--
+-- SmartEiffel is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License,
+-- as published by the Free Software Foundation; either version 2, or (at your option) any later version.
+-- SmartEiffel is distributed in the hope that it will be useful but WITHOUT ANY WARRANTY; without even the implied warranty
+-- of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have
+-- received a copy of the GNU General Public License along with SmartEiffel; see the file COPYING. If not, write to the Free
+-- Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+--
+-- Copyright(C) 1994-2002: INRIA - LORIA (INRIA Lorraine) - ESIAL U.H.P.       - University of Nancy 1 - FRANCE
+-- Copyright(C) 2003-2006: INRIA - LORIA (INRIA Lorraine) - I.U.T. Charlemagne - University of Nancy 2 - FRANCE
+--
+-- Authors: Dominique COLNET, Philippe RIBET, Cyril ADRIAN, Vincent CROIZIER, Frederic MERIZEN
+--
+-- http://SmartEiffel.loria.fr - SmartEiffel@loria.fr
+-- ------------------------------------------------------------------------------------------------------------------------------

--- a/test/language/error_warning_msg/bad_character3.msg
+++ b/test/language/error_warning_msg/bad_character3.msg
@@ -1,0 +1,6 @@
+****** Fatal Error: Unexpected character in decimal ascii code.
+
+Line 14 column 19 in BAD_CHARACTER3 (/home/cadrian/Workspace/Dev/Liberty/test/language/error_warning_msg/bad_character3.e):
+         c := '%/0?FF/'
+                  ^    
+------

--- a/test/language/error_warning_msg/eiffeltest/log.ref
+++ b/test/language/error_warning_msg/eiffeltest/log.ref
@@ -4,7 +4,7 @@ The reference file is "log.ref" and this file must be created manually.
 If you confirm that "log.new" is correct, just overwrite "log.ref" with "log.new".
 --------------------------------------------------------------------------------
 Found 0 test_* files.
-Found 411 bad_* files.
+Found 412 bad_* files.
 Found 2 subdirectories.
 --------------------------------------------------------------------------------
 se c bad_address_of1.e -o bad_address_of1.exe -style_warning -output_error_warning_on bad_address_of1.new
@@ -186,6 +186,8 @@ se c bad_character1.e -o bad_character1.exe -style_warning -output_error_warning
 Removing "bad_character1.new".
 se c bad_character2.e -o bad_character2.exe -style_warning -output_error_warning_on bad_character2.new
 Removing "bad_character2.new".
+se c bad_character3.e -o bad_character3.exe -style_warning -output_error_warning_on bad_character3.new
+Removing "bad_character3.new".
 se c bad_class1.e -o bad_class1.exe -style_warning -output_error_warning_on bad_class1.new
 Removing "bad_class1.new".
 se c bad_class2.e -o bad_class2.exe -style_warning -output_error_warning_on bad_class2.new


### PR DESCRIPTION
A character percent code with a leading 0 followed by any character in
the base position was being parsed as valid hexadecimal.

E.g., '%/0?FF/' = '%/0xFF/'

Does this expose an unknown issue with the bootstrapping compiler?