### PR TITLE
Remove straggling 'is" usage excluding wrappers

### DIFF
--- a/src/lib/abilities/internal/hoard.e
+++ b/src/lib/abilities/internal/hoard.e
@@ -49,7 +49,7 @@ feature {ANY} -- Agent-based features:
          if p ?:= action then
             p ::= action
          else
-            p := agent (a: ROUTINE[TUPLE[E_]]; e: E_) is do a.call([e]) end (action, ?)
+            p := agent (a: ROUTINE[TUPLE[E_]]; e: E_) do a.call([e]) end (action, ?)
          end
          for_each(p)
       end

--- a/src/lib/backtracking/node/backtracking_node_fill.e
+++ b/src/lib/backtracking/node/backtracking_node_fill.e
@@ -24,7 +24,7 @@ feature {ANY}
 feature {}
    fill_tagged_out_memory_flag: BOOLEAN
 
-   do_fill_tagged_out_memory is
+   do_fill_tagged_out_memory
       deferred
       end
 

--- a/src/lib/log/conf/log_file_options.e
+++ b/src/lib/log/conf/log_file_options.e
@@ -56,7 +56,7 @@ feature {}
          output_name := a_output_name
          file_path := a_file_path
          create {TEXT_FILE_WRITE} stream.connect_for_appending_to(a_file_path)
-         do_at_exit(agent is do if stream.is_connected then stream.disconnect end end)
+         do_at_exit(agent do if stream.is_connected then stream.disconnect end end)
          create {LOG_FILE_PASS_THROUGH} option.make
       ensure
          output_name = a_output_name

--- a/src/lib/log/conf/log_file_rotated.e
+++ b/src/lib/log/conf/log_file_rotated.e
@@ -116,7 +116,7 @@ feature {}
          end
 
          create {TEXT_FILE_WRITE} Result.connect_to(file_path)
-         do_at_exit(agent (file_: FILE_STREAM) is do if file_.is_connected then file_.disconnect end end (Result))
+         do_at_exit(agent (file_: FILE_STREAM) do if file_.is_connected then file_.disconnect end end (Result))
       ensure
          Result /= file
          Result.is_connected

--- a/src/lib/log/conf/log_internal_conf.e
+++ b/src/lib/log/conf/log_internal_conf.e
@@ -583,7 +583,7 @@ feature {}
          if ft.file_exists("log.rc") then
             create in.connect_to("log.rc")
             if in.is_connected then
-               load(in, Void, Void, agent (a_in: TEXT_FILE_READ) is do a_in.disconnect end(in))
+               load(in, Void, Void, agent (a_in: TEXT_FILE_READ) do a_in.disconnect end(in))
             end
             if root = Void then
                std_error.put_line(once "Could not initialize the logging framework.%NPlease check your log.rc file or explicitly call LOG_CONFIGURATION.load")

--- a/src/lib/parse/parse_table.e
+++ b/src/lib/parse/parse_table.e
@@ -130,7 +130,7 @@ feature {ANY}
 
    out_in_tagged_out_memory
       do
-         for_all_atoms(agent (atom: PARSE_ATOM[C_]) is do atom.out_in_tagged_out_memory; tagged_out_memory.extend('%N') end)
+         for_all_atoms(agent (atom: PARSE_ATOM[C_]) do atom.out_in_tagged_out_memory; tagged_out_memory.extend('%N') end)
       end
 
    pretty_print_on (stream: OUTPUT_STREAM)

--- a/src/lib/storage/map.e
+++ b/src/lib/storage/map.e
@@ -431,7 +431,7 @@ feature {ANY} -- Agents based features:
          if p ?:= action then
             p ::= action
          else
-            p := agent (v: V_; k: K_) is do action.call([v, k]) end (?, ?)
+            p := agent (v: V_; k: K_) do action.call([v, k]) end (?, ?)
          end
          for_each(p)
       end

--- a/src/smarteiffel/ace/ace.e
+++ b/src/smarteiffel/ace/ace.e
@@ -114,7 +114,7 @@ feature {ANY}
          root_index := root_index + 1
       end
 
-   reset_roots is
+   reset_roots
       do
          root_index := 0
       end

--- a/src/smarteiffel/ace/cluster.e
+++ b/src/smarteiffel/ace/cluster.e
@@ -104,7 +104,7 @@ feature {ANY}
       end
 
 feature {CLUSTER_POOL_DATA}
-   do_action (class_name: CLASS_NAME; action: PROCEDURE[TUPLE[CLASS_TEXT]]) is
+   do_action (class_name: CLASS_NAME; action: PROCEDURE[TUPLE[CLASS_TEXT]])
       do
          action.call([class_text(class_name, True)])
       end

--- a/src/smarteiffel/expression/manifest_tuple.e
+++ b/src/smarteiffel/expression/manifest_tuple.e
@@ -72,7 +72,7 @@ feature {ANY}
          pretty_printer.put_character('.')
       end
 
-   short (type: TYPE)is
+   short (type: TYPE)
       local
          i: INTEGER
       do

--- a/src/smarteiffel/generation/c/c_native_function_mapper.e
+++ b/src/smarteiffel/generation/c/c_native_function_mapper.e
@@ -688,7 +688,7 @@ feature {} -- built-ins
             end
          elseif as_calloc = name then
             if expanded_initializer(elt_type) then
-               cpp.memory.calloc(type_of_current.live_type, agent is do function_body.append(once "a1") end)
+               cpp.memory.calloc(type_of_current.live_type, agent do function_body.append(once "a1") end)
                function_body.append(once ";%Nr")
                type_of_current.id.append_in(function_body)
                function_body.append(once "clear_all(")

--- a/src/smarteiffel/generation/c/c_pretty_printer.e
+++ b/src/smarteiffel/generation/c/c_pretty_printer.e
@@ -4030,7 +4030,7 @@ feature {} -- MANIFEST_GENERIC_POOL
          pending_c_function_body.append(once "*/%NT")
          native_array_id.append_in(pending_c_function_body)
          pending_c_function_body.append(once " C=")
-         memory.calloc(native_array.live_type, agent is do pending_c_function_body.append(once "argc") end)
+         memory.calloc(native_array.live_type, agent do pending_c_function_body.append(once "argc") end)
          pending_c_function_body.append(once ";%Nreturn C;%N")
          dump_pending_c_function(True)
 
@@ -4051,7 +4051,7 @@ feature {} -- MANIFEST_GENERIC_POOL
          pending_c_function_signature.append(once " C,int i,int argc,...)")
          -- Prepare body:
          pending_c_function_body.append(once "va_list pa;%Nva_start(pa,argc);%NC=")
-         memory.calloc(native_array.live_type, agent is do pending_c_function_body.append(once "argc") end)
+         memory.calloc(native_array.live_type, agent do pending_c_function_body.append(once "argc") end)
          pending_c_function_body.append(once ";%Nwhile (i < argc) {%N")
          pending_c_function_body.append(argument_type.for(va_type))
          pending_c_function_body.append(once " element=((")

--- a/src/smarteiffel/parser/eiffel_parser.e
+++ b/src/smarteiffel/parser/eiffel_parser.e
@@ -28,7 +28,7 @@ feature {ANY}
    total_time: INTEGER_64
 
 feature {ANY}
-   predefined_type_mark (tm: STRING; sp: POSITION): TYPE_MARK is
+   predefined_type_mark (tm: STRING; sp: POSITION): TYPE_MARK
       require
          tm /= Void
       do
@@ -4794,7 +4794,7 @@ feature {}
          end
       end
 
-   inline_agent_no_name: FEATURE_NAME is
+   inline_agent_no_name: FEATURE_NAME
       once
          create Result.unknown_position("__inline_agent__")
          Result.set_is_frozen

--- a/src/smarteiffel/parser/tmp_feature.e
+++ b/src/smarteiffel/parser/tmp_feature.e
@@ -424,8 +424,8 @@ feature {}
       do
          if type = Void or else arguments /= Void then
             if constant_expression /= Void then
-               error_handler.append(once "Using a static constant expression just after the %"is%" keyword %
-                                    %is suitable only for a constant attribute definition. The constant %
+               error_handler.append(once "Bad constant-attribute definition. Using a manifest constant for the feature %
+                                    %value is suitable only for a constant-attribute definition. The constant %
                                     %found (i.e. ")
                error_handler.add_expression(constant_expression)
                error_handler.append(once ") cannot be used as the definition of the feature ")
@@ -437,11 +437,10 @@ feature {}
             error_handler.append(once " Actually, feature ")
             error_handler.add_feature_name(names.first)
             if type = Void then
-               error_handler.append(once " has no result type")
+               error_handler.append(once " has no result type.")
             else
-               error_handler.append(once " has an argument list")
+               error_handler.append(once " has an argument list.")
             end
-            error_handler.append(once ". Bad constant-attribute definition.")
             error_handler.add_position(names.first.start_position)
             error_handler.print_as_fatal_error
          elseif not type.is_static then

--- a/src/smarteiffel/parser/tmp_feature.e
+++ b/src/smarteiffel/parser/tmp_feature.e
@@ -115,7 +115,7 @@ feature {EIFFEL_PARSER}
          names.add_last(a_name)
       end
 
-   clear_synonyms is
+   clear_synonyms
       require
          not names.is_empty
       do

--- a/src/smarteiffel/utils/syntax/parent_edge.e
+++ b/src/smarteiffel/utils/syntax/parent_edge.e
@@ -21,7 +21,7 @@ create {ANY}
    make
 
 feature {ANY}
-   is_equal (other: like Current): BOOLEAN is
+   is_equal (other: like Current): BOOLEAN
       do
          Result := other = Current
       end

--- a/test/language/error_warning_msg/bad_constant2.msg
+++ b/test/language/error_warning_msg/bad_constant2.msg
@@ -1,8 +1,7 @@
-****** Fatal Error: Using a static constant expression just after
-the "is" keyword is suitable only for a constant attribute definition.
-The constant found (i.e. `0.0') cannot be used as the definition
-of the feature `zero'. Actually, feature `zero' has no result
-type. Bad constant-attribute definition.
+****** Fatal Error: Bad constant-attribute definition. Using a manifest
+constant for the feature value is suitable only for a constant-attribute
+definition. The constant found (i.e. `0.0') cannot be used as the definition of
+the feature `zero'. Actually, feature `zero' has no result type.
 
 Line 13 column 4 in BAD_CONSTANT2 (/home/cadrian/Workspace/Dev/Liberty/test/language/error_warning_msg/bad_constant2.e):
    zero 0.0;

--- a/test/language/error_warning_msg/bad_constant9.msg
+++ b/test/language/error_warning_msg/bad_constant9.msg
@@ -1,8 +1,8 @@
-****** Fatal Error: Using a static constant expression just after
-the "is" keyword is suitable only for a constant attribute definition.
-The constant found (i.e. `3') cannot be used as the definition
-of the feature `f'. Actually, feature `f' has an argument list.
-Bad constant-attribute definition.
+****** Fatal Error: Bad constant-attribute definition. Using a manifest
+constant for the feature value is suitable only for a constant-attribute
+definition. The constant found (i.e. `3') cannot be used as the definition of
+the feature `f'. Actually, feature `f' has an argument list.
+
 
 Line 15 column 4 in BAD_CONSTANT9 (/home/cadrian/Workspace/Dev/Liberty/test/language/error_warning_msg/bad_constant9.e):
    f (i:INTEGER): INTEGER 3

--- a/work/legacy/llvm/generation/llvm_bytecode_emitter.e
+++ b/work/legacy/llvm/generation/llvm_bytecode_emitter.e
@@ -45,7 +45,7 @@ feature {SMART_EIFFEL}
                         create workers.with_capacity(workers_count)
                         socket_path := "ipc:///tmp/liberty-llvm-compiler-"+process_id.out
                         controller_path := "ipc:///tmp/liberty-llvm-compiler-controller-"+process_id.out
-                        workers_count.times(agent is do
+                        workers_count.times(agent do
                                 workers.add_last(create {LLVM_WORKER}.communicating_over(socket_path))
                         end)
 

--- a/work/legacy/llvm/generation/llvm_worker.e
+++ b/work/legacy/llvm/generation/llvm_worker.e
@@ -117,146 +117,146 @@ feature {ANY} -- Implementation
                 end
 
 feature {ANY} -- Attributes compiling
-        visit_cst_att_boolean (visited: CST_ATT_BOOLEAN) is do not_yet_implemented end
-        visit_cst_att_character (a_cst_att_char: CST_ATT_CHARACTER) is do not_yet_implemented end
-        visit_cst_att_integer (visited: CST_ATT_INTEGER) is do not_yet_implemented end
-        visit_cst_att_real (visited: CST_ATT_REAL) is do not_yet_implemented end
-        visit_cst_att_string (visited: CST_ATT_STRING) is do not_yet_implemented end
-        visit_cst_att_unique (a_unique_cst_att: CST_ATT_UNIQUE) is do not_yet_implemented end
-        visit_writable_attribute (visited: WRITABLE_ATTRIBUTE) is do not_yet_implemented end
+        visit_cst_att_boolean (visited: CST_ATT_BOOLEAN) do not_yet_implemented end
+        visit_cst_att_character (a_cst_att_char: CST_ATT_CHARACTER) do not_yet_implemented end
+        visit_cst_att_integer (visited: CST_ATT_INTEGER) do not_yet_implemented end
+        visit_cst_att_real (visited: CST_ATT_REAL) do not_yet_implemented end
+        visit_cst_att_string (visited: CST_ATT_STRING) do not_yet_implemented end
+        visit_cst_att_unique (a_unique_cst_att: CST_ATT_UNIQUE) do not_yet_implemented end
+        visit_writable_attribute (visited: WRITABLE_ATTRIBUTE) do not_yet_implemented end
 
 feature {ANY} -- Functions and procedures compiling
-        visit_deferred_function (visited: DEFERRED_FUNCTION) is do not_yet_implemented end
-        visit_deferred_procedure (a_deferred_procedure: DEFERRED_PROCEDURE) is do not_yet_implemented end
-        visit_e_function (visited: E_FUNCTION) is do not_yet_implemented end
-        visit_e_procedure (visited: E_PROCEDURE) is do not_yet_implemented end
-        visit_external_function (visited: EXTERNAL_FUNCTION) is do not_yet_implemented end
-        visit_external_procedure (visited: EXTERNAL_PROCEDURE) is do not_yet_implemented end
-        visit_once_function (an_once_function: ONCE_FUNCTION) is do not_yet_implemented end
-        visit_once_procedure (an_once_procedure: ONCE_PROCEDURE) is do not_yet_implemented end
+        visit_deferred_function (visited: DEFERRED_FUNCTION) do not_yet_implemented end
+        visit_deferred_procedure (a_deferred_procedure: DEFERRED_PROCEDURE) do not_yet_implemented end
+        visit_e_function (visited: E_FUNCTION) do not_yet_implemented end
+        visit_e_procedure (visited: E_PROCEDURE) do not_yet_implemented end
+        visit_external_function (visited: EXTERNAL_FUNCTION) do not_yet_implemented end
+        visit_external_procedure (visited: EXTERNAL_PROCEDURE) do not_yet_implemented end
+        visit_once_function (an_once_function: ONCE_FUNCTION) do not_yet_implemented end
+        visit_once_procedure (an_once_procedure: ONCE_PROCEDURE) do not_yet_implemented end
 
 feature {ANY} -- Native features compiling
-        visit_native_built_in (visited: NATIVE_BUILT_IN) is do not_yet_implemented end
-        visit_native_c (visited: NATIVE_C) is do not_yet_implemented end
-        visit_native_c_plus_plus (visited: NATIVE_C_PLUS_PLUS) is do not_yet_implemented end
-        visit_native_plug_in (visited: NATIVE_PLUG_IN) is do not_yet_implemented end
+        visit_native_built_in (visited: NATIVE_BUILT_IN) do not_yet_implemented end
+        visit_native_c (visited: NATIVE_C) do not_yet_implemented end
+        visit_native_c_plus_plus (visited: NATIVE_C_PLUS_PLUS) do not_yet_implemented end
+        visit_native_plug_in (visited: NATIVE_PLUG_IN) do not_yet_implemented end
 
 feature {ANY} -- Instructions compiling
-        visit_agent_instruction (visited: AGENT_INSTRUCTION) is do not_yet_implemented end
-        visit_assertion_list (visited: ASSERTION_LIST) is do not_yet_implemented end
-        visit_assignment (visited: ASSIGNMENT) is do not_yet_implemented end
-        visit_assignment_attempt (visited: ASSIGNMENT_ATTEMPT) is do not_yet_implemented end
-        visit_c_inline (visited: C_INLINE) is do not_yet_implemented end
-        visit_check_compound (visited: CHECK_COMPOUND) is do not_yet_implemented end
-        visit_class_invariant (visited: CLASS_INVARIANT) is do not_yet_implemented end
-        visit_comment (visited: COMMENT) is do not_yet_implemented end
-        visit_compound (visited: COMPOUND) is do not_yet_implemented end
-        visit_create_instruction (visited: CREATE_INSTRUCTION) is do not_yet_implemented end
-        visit_debug_compound (visited: DEBUG_COMPOUND) is do not_yet_implemented end
-        visit_ensure_assertion (visited: ENSURE_ASSERTION) is do not_yet_implemented end
-        visit_ifthen (visited: IFTHEN) is do not_yet_implemented end
-        visit_ifthenelse (visited: IFTHENELSE) is do not_yet_implemented end
-        visit_loop_instruction (visited: LOOP_INSTRUCTION) is do not_yet_implemented end
-        visit_loop_invariant (visited: LOOP_INVARIANT) is do not_yet_implemented end
-        visit_manifest_string_inspect_statement (visited: MANIFEST_STRING_INSPECT_STATEMENT) is do not_yet_implemented end
-        visit_other_inspect_statement (visited: OTHER_INSPECT_STATEMENT) is do not_yet_implemented end
-        visit_precursor_instruction (visited: PRECURSOR_INSTRUCTION) is do not_yet_implemented end
-        visit_procedure_call_0 (visited: PROCEDURE_CALL_0) is do not_yet_implemented end
-        visit_procedure_call_1 (visited: PROCEDURE_CALL_1) is do not_yet_implemented end
-        visit_procedure_call_n (visited: PROCEDURE_CALL_N) is do not_yet_implemented end
-        visit_raw_create_instruction (visited: RAW_CREATE_INSTRUCTION) is do not_yet_implemented end
-        visit_require_assertion (visited: REQUIRE_ASSERTION) is do not_yet_implemented end
-        visit_retry_instruction (visited: RETRY_INSTRUCTION) is do not_yet_implemented end
-        visit_static_call_0_c (visited: STATIC_CALL_0_C) is do not_yet_implemented end
-        visit_when_clause (visited: WHEN_CLAUSE) is do not_yet_implemented end
+        visit_agent_instruction (visited: AGENT_INSTRUCTION) do not_yet_implemented end
+        visit_assertion_list (visited: ASSERTION_LIST) do not_yet_implemented end
+        visit_assignment (visited: ASSIGNMENT) do not_yet_implemented end
+        visit_assignment_attempt (visited: ASSIGNMENT_ATTEMPT) do not_yet_implemented end
+        visit_c_inline (visited: C_INLINE) do not_yet_implemented end
+        visit_check_compound (visited: CHECK_COMPOUND) do not_yet_implemented end
+        visit_class_invariant (visited: CLASS_INVARIANT) do not_yet_implemented end
+        visit_comment (visited: COMMENT) do not_yet_implemented end
+        visit_compound (visited: COMPOUND) do not_yet_implemented end
+        visit_create_instruction (visited: CREATE_INSTRUCTION) do not_yet_implemented end
+        visit_debug_compound (visited: DEBUG_COMPOUND) do not_yet_implemented end
+        visit_ensure_assertion (visited: ENSURE_ASSERTION) do not_yet_implemented end
+        visit_ifthen (visited: IFTHEN) do not_yet_implemented end
+        visit_ifthenelse (visited: IFTHENELSE) do not_yet_implemented end
+        visit_loop_instruction (visited: LOOP_INSTRUCTION) do not_yet_implemented end
+        visit_loop_invariant (visited: LOOP_INVARIANT) do not_yet_implemented end
+        visit_manifest_string_inspect_statement (visited: MANIFEST_STRING_INSPECT_STATEMENT) do not_yet_implemented end
+        visit_other_inspect_statement (visited: OTHER_INSPECT_STATEMENT) do not_yet_implemented end
+        visit_precursor_instruction (visited: PRECURSOR_INSTRUCTION) do not_yet_implemented end
+        visit_procedure_call_0 (visited: PROCEDURE_CALL_0) do not_yet_implemented end
+        visit_procedure_call_1 (visited: PROCEDURE_CALL_1) do not_yet_implemented end
+        visit_procedure_call_n (visited: PROCEDURE_CALL_N) do not_yet_implemented end
+        visit_raw_create_instruction (visited: RAW_CREATE_INSTRUCTION) do not_yet_implemented end
+        visit_require_assertion (visited: REQUIRE_ASSERTION) do not_yet_implemented end
+        visit_retry_instruction (visited: RETRY_INSTRUCTION) do not_yet_implemented end
+        visit_static_call_0_c (visited: STATIC_CALL_0_C) do not_yet_implemented end
+        visit_when_clause (visited: WHEN_CLAUSE) do not_yet_implemented end
 
 
         -- strange features, please cast me some light on them....
-        visit_no_invariant_wrapper (visited: NO_INVARIANT_WRAPPER) is do not_yet_implemented end
+        visit_no_invariant_wrapper (visited: NO_INVARIANT_WRAPPER) do not_yet_implemented end
         -- Non written instructions...
-        visit_run_time_error_instruction (visited: RUN_TIME_ERROR_INSTRUCTION) is do not_yet_implemented end
-        visit_sedb (visited: SEDB) is do not_yet_implemented end
-        visit_unused_expression (visited: UNUSED_EXPRESSION) is do not_yet_implemented end
-        visit_void_proc_call (visited: VOID_PROC_CALL) is do not_yet_implemented end
+        visit_run_time_error_instruction (visited: RUN_TIME_ERROR_INSTRUCTION) do not_yet_implemented end
+        visit_sedb (visited: SEDB) do not_yet_implemented end
+        visit_unused_expression (visited: UNUSED_EXPRESSION) do not_yet_implemented end
+        visit_void_proc_call (visited: VOID_PROC_CALL) do not_yet_implemented end
 
 feature {ANY} -- Prefix compiling
-        visit_call_prefix_freeop (visited: CALL_PREFIX_FREEOP) is do not_yet_implemented end
-        visit_call_prefix_minus (visited: CALL_PREFIX_MINUS) is do not_yet_implemented end
-        visit_call_prefix_not (visited: CALL_PREFIX_NOT) is do not_yet_implemented end
-        visit_call_prefix_plus (visited: CALL_PREFIX_PLUS) is do not_yet_implemented end
+        visit_call_prefix_freeop (visited: CALL_PREFIX_FREEOP) do not_yet_implemented end
+        visit_call_prefix_minus (visited: CALL_PREFIX_MINUS) do not_yet_implemented end
+        visit_call_prefix_not (visited: CALL_PREFIX_NOT) do not_yet_implemented end
+        visit_call_prefix_plus (visited: CALL_PREFIX_PLUS) do not_yet_implemented end
 
 feature {ANY} -- Infix Compiling
-        visit_call_infix_and_then (visited: CALL_INFIX_AND_THEN) is do not_yet_implemented end
-        visit_call_infix_and (visited: CALL_INFIX_AND) is do not_yet_implemented end
-        visit_call_infix_div (visited: CALL_INFIX_DIV) is do not_yet_implemented end
-        visit_call_infix_freeop (visited: CALL_INFIX_FREEOP) is do not_yet_implemented end
-        visit_call_infix_ge (visited: CALL_INFIX_GE) is do not_yet_implemented end
-        visit_call_infix_gt (visited: CALL_INFIX_GT) is do not_yet_implemented end
-        visit_call_infix_implies (visited: CALL_INFIX_IMPLIES) is do not_yet_implemented end
-        visit_call_infix_int_div (visited: CALL_INFIX_INT_DIV) is do not_yet_implemented end
-        visit_call_infix_int_rem (visited: CALL_INFIX_INT_REM) is do not_yet_implemented end
-        visit_call_infix_le (visited: CALL_INFIX_LE) is do not_yet_implemented end
-        visit_call_infix_lt (visited: CALL_INFIX_LT) is do not_yet_implemented end
-        visit_call_infix_minus (visited: CALL_INFIX_MINUS) is do not_yet_implemented end
-        visit_call_infix_or_else (visited: CALL_INFIX_OR_ELSE) is do not_yet_implemented end
-        visit_call_infix_or (visited: CALL_INFIX_OR) is do not_yet_implemented end
-        visit_call_infix_plus (visited: CALL_INFIX_PLUS) is do not_yet_implemented end
-        visit_call_infix_power (visited: CALL_INFIX_POWER) is do not_yet_implemented end
-        visit_call_infix_times (visited: CALL_INFIX_TIMES) is do not_yet_implemented end
-        visit_call_infix_xor (visited: CALL_INFIX_XOR) is do not_yet_implemented end
+        visit_call_infix_and_then (visited: CALL_INFIX_AND_THEN) do not_yet_implemented end
+        visit_call_infix_and (visited: CALL_INFIX_AND) do not_yet_implemented end
+        visit_call_infix_div (visited: CALL_INFIX_DIV) do not_yet_implemented end
+        visit_call_infix_freeop (visited: CALL_INFIX_FREEOP) do not_yet_implemented end
+        visit_call_infix_ge (visited: CALL_INFIX_GE) do not_yet_implemented end
+        visit_call_infix_gt (visited: CALL_INFIX_GT) do not_yet_implemented end
+        visit_call_infix_implies (visited: CALL_INFIX_IMPLIES) do not_yet_implemented end
+        visit_call_infix_int_div (visited: CALL_INFIX_INT_DIV) do not_yet_implemented end
+        visit_call_infix_int_rem (visited: CALL_INFIX_INT_REM) do not_yet_implemented end
+        visit_call_infix_le (visited: CALL_INFIX_LE) do not_yet_implemented end
+        visit_call_infix_lt (visited: CALL_INFIX_LT) do not_yet_implemented end
+        visit_call_infix_minus (visited: CALL_INFIX_MINUS) do not_yet_implemented end
+        visit_call_infix_or_else (visited: CALL_INFIX_OR_ELSE) do not_yet_implemented end
+        visit_call_infix_or (visited: CALL_INFIX_OR) do not_yet_implemented end
+        visit_call_infix_plus (visited: CALL_INFIX_PLUS) do not_yet_implemented end
+        visit_call_infix_power (visited: CALL_INFIX_POWER) do not_yet_implemented end
+        visit_call_infix_times (visited: CALL_INFIX_TIMES) do not_yet_implemented end
+        visit_call_infix_xor (visited: CALL_INFIX_XOR) do not_yet_implemented end
 
 feature {ANY} -- Expression compiling
-        visit_address_of (visited: ADDRESS_OF) is do not_yet_implemented end
-        visit_agent_creation (visited: AGENT_CREATION) is do not_yet_implemented end
-        visit_argument_name_ref (visited: ARGUMENT_NAME_REF) is do not_yet_implemented end
-        visit_agent_expression (visited: AGENT_EXPRESSION) is do not_yet_implemented end
-        visit_assertion (visited: ASSERTION) is do not_yet_implemented end
-        visit_assignment_test (visited: ASSIGNMENT_TEST) is do not_yet_implemented end
-        visit_built_in_eq_neq (visited: BUILT_IN_EQ_NEQ) is do not_yet_implemented end
-        visit_closed_operand (visited: CLOSED_OPERAND) is do not_yet_implemented end
-        visit_compound_expression (visited: COMPOUND_EXPRESSION) is do not_yet_implemented end
-        visit_create_expression (visited: CREATE_EXPRESSION) is do not_yet_implemented end
-        visit_create_writable (visited: CREATE_WRITABLE) is do not_yet_implemented end
-        visit_dynamic_dispatch_temporary1_id (visited: DYNAMIC_DISPATCH_TEMPORARY1_ID) is do not_yet_implemented end
-   visit_dynamic_dispatch_temporary1 (visited: DYNAMIC_DISPATCH_TEMPORARY1) is do not_yet_implemented end
-   visit_dynamic_dispatch_temporary2 (visited: DYNAMIC_DISPATCH_TEMPORARY2) is do not_yet_implemented end
-   visit_e_false (visited: E_FALSE) is do not_yet_implemented end
-        visit_e_old (visited: E_OLD) is do not_yet_implemented end
-   visit_e_true (visited: E_TRUE) is do not_yet_implemented end
-        visit_expression_with_comment (visited: EXPRESSION_WITH_COMMENT) is do not_yet_implemented end
-        visit_fake_argument (visited: FAKE_ARGUMENT) is do not_yet_implemented end
-        visit_fake_target (visited: FAKE_TARGET) is do not_yet_implemented end
-        visit_fake_tuple (visited: FAKE_TUPLE) is do not_yet_implemented end
-   visit_function_call_0 (visited: FUNCTION_CALL_0) is do not_yet_implemented end
-   visit_function_call_1 (visited: FUNCTION_CALL_1) is do not_yet_implemented end
-   visit_function_call_n (visited: FUNCTION_CALL_N) is do not_yet_implemented end
-        visit_generator_generating_type (visited: GENERATOR_GENERATING_TYPE) is do not_yet_implemented end
-        visit_implicit_cast (visited: IMPLICIT_CAST) is do not_yet_implemented end
-   visit_implicit_current (visited: IMPLICIT_CURRENT) is do not_yet_implemented end
-   visit_internal_local2 (visited: INTERNAL_LOCAL2) is do not_yet_implemented end
-        visit_local_name_ref (visited: LOCAL_NAME_REF) is do not_yet_implemented end
-        visit_loop_variant (visited: LOOP_VARIANT) is do not_yet_implemented end
-        visit_native_array_item (visited: NATIVE_ARRAY_ITEM) is do not_yet_implemented end
-   visit_no_dispatch (visited: NO_DISPATCH) is do not_yet_implemented end
-   visit_non_void_no_dispatch (visited: NON_VOID_NO_DISPATCH) is do not_yet_implemented end
-   visit_null_pointer (visited: NULL_POINTER) is do not_yet_implemented end
-        visit_open_operand (visited: OPEN_OPERAND) is do not_yet_implemented end
-        visit_precursor_expression (visited: PRECURSOR_EXPRESSION) is do not_yet_implemented end
-        visit_result (visited: RESULT) is do not_yet_implemented end
-   visit_void_call (visited: VOID_CALL) is do not_yet_implemented end
-        visit_writable_attribute_name (visited: WRITABLE_ATTRIBUTE_NAME) is do not_yet_implemented end
-   visit_written_current (visited: WRITTEN_CURRENT) is do not_yet_implemented end
+        visit_address_of (visited: ADDRESS_OF) do not_yet_implemented end
+        visit_agent_creation (visited: AGENT_CREATION) do not_yet_implemented end
+        visit_argument_name_ref (visited: ARGUMENT_NAME_REF) do not_yet_implemented end
+        visit_agent_expression (visited: AGENT_EXPRESSION) do not_yet_implemented end
+        visit_assertion (visited: ASSERTION) do not_yet_implemented end
+        visit_assignment_test (visited: ASSIGNMENT_TEST) do not_yet_implemented end
+        visit_built_in_eq_neq (visited: BUILT_IN_EQ_NEQ) do not_yet_implemented end
+        visit_closed_operand (visited: CLOSED_OPERAND) do not_yet_implemented end
+        visit_compound_expression (visited: COMPOUND_EXPRESSION) do not_yet_implemented end
+        visit_create_expression (visited: CREATE_EXPRESSION) do not_yet_implemented end
+        visit_create_writable (visited: CREATE_WRITABLE) do not_yet_implemented end
+        visit_dynamic_dispatch_temporary1_id (visited: DYNAMIC_DISPATCH_TEMPORARY1_ID) do not_yet_implemented end
+   visit_dynamic_dispatch_temporary1 (visited: DYNAMIC_DISPATCH_TEMPORARY1) do not_yet_implemented end
+   visit_dynamic_dispatch_temporary2 (visited: DYNAMIC_DISPATCH_TEMPORARY2) do not_yet_implemented end
+   visit_e_false (visited: E_FALSE) do not_yet_implemented end
+        visit_e_old (visited: E_OLD) do not_yet_implemented end
+   visit_e_true (visited: E_TRUE) do not_yet_implemented end
+        visit_expression_with_comment (visited: EXPRESSION_WITH_COMMENT) do not_yet_implemented end
+        visit_fake_argument (visited: FAKE_ARGUMENT) do not_yet_implemented end
+        visit_fake_target (visited: FAKE_TARGET) do not_yet_implemented end
+        visit_fake_tuple (visited: FAKE_TUPLE) do not_yet_implemented end
+   visit_function_call_0 (visited: FUNCTION_CALL_0) do not_yet_implemented end
+   visit_function_call_1 (visited: FUNCTION_CALL_1) do not_yet_implemented end
+   visit_function_call_n (visited: FUNCTION_CALL_N) do not_yet_implemented end
+        visit_generator_generating_type (visited: GENERATOR_GENERATING_TYPE) do not_yet_implemented end
+        visit_implicit_cast (visited: IMPLICIT_CAST) do not_yet_implemented end
+   visit_implicit_current (visited: IMPLICIT_CURRENT) do not_yet_implemented end
+   visit_internal_local2 (visited: INTERNAL_LOCAL2) do not_yet_implemented end
+        visit_local_name_ref (visited: LOCAL_NAME_REF) do not_yet_implemented end
+        visit_loop_variant (visited: LOOP_VARIANT) do not_yet_implemented end
+        visit_native_array_item (visited: NATIVE_ARRAY_ITEM) do not_yet_implemented end
+   visit_no_dispatch (visited: NO_DISPATCH) do not_yet_implemented end
+   visit_non_void_no_dispatch (visited: NON_VOID_NO_DISPATCH) do not_yet_implemented end
+   visit_null_pointer (visited: NULL_POINTER) do not_yet_implemented end
+        visit_open_operand (visited: OPEN_OPERAND) do not_yet_implemented end
+        visit_precursor_expression (visited: PRECURSOR_EXPRESSION) do not_yet_implemented end
+        visit_result (visited: RESULT) do not_yet_implemented end
+   visit_void_call (visited: VOID_CALL) do not_yet_implemented end
+        visit_writable_attribute_name (visited: WRITABLE_ATTRIBUTE_NAME) do not_yet_implemented end
+   visit_written_current (visited: WRITTEN_CURRENT) do not_yet_implemented end
 
 feature {ANY} -- Manifest expressions
-        visit_e_void (visited: E_VOID) is do not_yet_implemented end
-   visit_manifest_string (visited: MANIFEST_STRING) is do not_yet_implemented end
-   visit_manifest_generic (visited: MANIFEST_GENERIC) is do not_yet_implemented end
-        visit_manifest_tuple (visited: MANIFEST_TUPLE) is do not_yet_implemented end
-        visit_old_manifest_array (visited: OLD_MANIFEST_ARRAY) is do not_yet_implemented end
+        visit_e_void (visited: E_VOID) do not_yet_implemented end
+   visit_manifest_string (visited: MANIFEST_STRING) do not_yet_implemented end
+   visit_manifest_generic (visited: MANIFEST_GENERIC) do not_yet_implemented end
+        visit_manifest_tuple (visited: MANIFEST_TUPLE) do not_yet_implemented end
+        visit_old_manifest_array (visited: OLD_MANIFEST_ARRAY) do not_yet_implemented end
 
 feature {ANY} -- Constant expression
-        visit_character_constant (visited: CHARACTER_CONSTANT) is do not_yet_implemented end
-        visit_integer_constant (visited: INTEGER_CONSTANT) is do not_yet_implemented end
+        visit_character_constant (visited: CHARACTER_CONSTANT) do not_yet_implemented end
+        visit_integer_constant (visited: INTEGER_CONSTANT) do not_yet_implemented end
         visit_real_constant (a_real_constant: REAL_CONSTANT)
                 local llvm_constant: LLVM_CONSTANT_FP
                 do

--- a/work/legacy/tools/configuration/etc/liberty_etc_cluster.e
+++ b/work/legacy/tools/configuration/etc/liberty_etc_cluster.e
@@ -114,7 +114,7 @@ feature {LIBERTY_ETC_VISITOR_IMPL}
 
    check_cycles
       do
-         needs_memory.do_all(agent (n: LIBERTY_ETC_NEEDS) is do n.cluster.check_cycle(Current, n) end)
+         needs_memory.do_all(agent (n: LIBERTY_ETC_NEEDS) do n.cluster.check_cycle(Current, n) end)
       end
 
 feature {LIBERTY_ETC_CLUSTER}


### PR DESCRIPTION
Leaving wrappers/ alone for now as I assume it's largely been excluded from previous "is" removal for a reason.