### PR TITLE
fix writable attribute header comment parsing

### DIFF
--- a/src/smarteiffel/parser/eiffel_parser.e
+++ b/src/smarteiffel/parser/eiffel_parser.e
@@ -5175,7 +5175,9 @@ feature {}
                else
                   last_feature_declaration := tmp_feature.as_writable_attribute
                   ok := skip1(';')
-                  last_feature_declaration.set_header_comment(get_comment)
+                  if tmp_feature.header_comment = Void then
+                     last_feature_declaration.set_header_comment(get_comment)
+                  end
                end
             end
 


### PR DESCRIPTION
The header comment was being dropped when there was no ';' ending the
declaration.

This looks like collateral damage from making "is" optional.  I think the fix is in keeping with the prevailing style.