### PR TITLE
System independent germ compilation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -315,12 +315,14 @@ EOF
 
     if [ ! -d $TARGET/bin/compile_to_c.d ]; then
         test -d $TARGET/bin/compile_to_c.d || mkdir $TARGET/bin/compile_to_c.d
-        grep -v '^#' compile_to_c.make |
-            while read cmd; do
-                progress 30 0 $MAXTOOLCOUNT "germ: $cmd"
-                run $cmd || exit 1
-                test -e a.exe && mv a.exe a.out
-            done
+       for src in compile_to_c{135..1}.c ; do
+           germ_copts="-O2 -c -x c"
+           cmd="${CC} ${CFLAGS} ${germ_copts} ${src}"
+            progress 30 0 $MAXTOOLCOUNT "germ: $cmd"
+            run $cmd || exit 1
+        done
+       ${CC} ${LDFLAGS} *.o
+        test -e a.exe && mv a.exe a.out
         cp -a * $TARGET/bin/compile_to_c.d/
     fi
     cd $TARGET/bin/compile_to_c.d

--- a/install.sh
+++ b/install.sh
@@ -316,7 +316,6 @@ EOF
     if [ ! -d $TARGET/bin/compile_to_c.d ]; then
         test -d $TARGET/bin/compile_to_c.d || mkdir $TARGET/bin/compile_to_c.d
        for src in compile_to_c{135..1}.c ; do
-           germ_copts="-O2 -c -x c"
            cmd="${CC} ${CFLAGS} ${germ_copts} ${src}"
             progress 30 0 $MAXTOOLCOUNT "germ: $cmd"
             run $cmd || exit 1

--- a/work/tools.sh
+++ b/work/tools.sh
@@ -8,14 +8,17 @@ case `uname -s` in
 	flavor=generic
 	OS=Cygwin
 	EXE_SUFFIX=".exe"
+        germ_copts="-O2 -c -x c"
 	;;
     Linux)
 	flavor=Linux
 	jobs=$((1 + $(grep '^processor' /proc/cpuinfo|wc -l)))
+        germ_copts="-O2 -c -x c"
 	;;
     Darwin)
 	flavor=Darwin
 	jobs=$((1 + $(sysctl -n machdep.cpu.core_count)))
+        germ_copts="-O2 -c -x c"
 	;;
     *)
 	flavor=uknown


### PR DESCRIPTION
     This is based on a suggestion from Raphael Mack on the mailing list.

     We want to try and make the boostrap system-independent so we are
     not using the .make file in the germ, but rather compiling using
     the settings from work/tools.sh.

     Assumption:  The number of files will remain the same.

     If the order in which files are compiled does not matter, the assumption
     is invalid and we can use 'gcc *.c'