### PR TITLE
Update gc_lib.c, macro GC_BUG in (boost mode) creates and dereferences an otherwise unused pointer to zero.  Line in macro disabled for now...

### DIFF
--- a/sys/runtime/c/gc_lib.c
+++ b/sys/runtime/c/gc_lib.c
@@ -83,7 +83,7 @@
 #    define GC_BUG(tag, expr) do {if (expr) {    \
          handle(SE_HANDLE_RUNTIME_ERROR, NULL); \
          se_print_run_time_stack();             \
-         {int *i=0;*i=0;}                       \
+         // {int *i=0;*i=0;}                       \
          exit(EXIT_FAILURE);                    \
       }} while(0)
 #else


### PR DESCRIPTION
Offending macro line commented out for now, pending tests after merge.