### PR TITLE
macOS is POSIX

### DIFF
--- a/src/lib/i18n/externals/plugin/c/i18n.c
+++ b/src/lib/i18n/externals/plugin/c/i18n.c
@@ -1,4 +1,4 @@
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 void i18n_set_system_locale (void* language, void* country, void* encoding) {
   static char locale[32];

--- a/src/lib/i18n/externals/plugin/c/i18n.h
+++ b/src/lib/i18n/externals/plugin/c/i18n.h
@@ -1,4 +1,4 @@
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/wrappers/ewlc/eiffel-glib/library/externals/cecil.h
+++ b/src/wrappers/ewlc/eiffel-glib/library/externals/cecil.h
@@ -61,7 +61,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 #  include <unistd.h>
 #endif
 #if !defined(WIN32) && \

--- a/sys/plugins/exec/c/exec.h
+++ b/sys/plugins/exec/c/exec.h
@@ -36,7 +36,7 @@
  * basic_exec_xxx          *
  ***************************/
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined(__APPLE__) && defined(__MACH__))
 
 /*#  include <unistd.h> done in base.h */
 /*#  include <sys/types.h> done in base.h */

--- a/sys/plugins/exec/pipes/c/exec_pipes.c
+++ b/sys/plugins/exec/pipes/c/exec_pipes.c
@@ -25,7 +25,7 @@
 -- http://SmartEiffel.loria.fr - SmartEiffel@loria.fr
 -- ------------------------------------------------------------------------------------------------------------
 */
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 se_pipe_data_t* basic_exec_pipe_create(void) {
   se_pipe_data_t* result = NULL;

--- a/sys/plugins/exec/pipes/c/exec_pipes.h
+++ b/sys/plugins/exec/pipes/c/exec_pipes.h
@@ -25,7 +25,7 @@
 -- http://SmartEiffel.loria.fr - SmartEiffel@loria.fr
 -- ------------------------------------------------------------------------------------------------------------
 */
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 /*#  include <unistd.h> done in base.h */
 /*#  include <sys/types.h> done in base.h */
 

--- a/sys/plugins/io/c/io.c
+++ b/sys/plugins/io/c/io.c
@@ -25,7 +25,7 @@
 -- http://SmartEiffel.loria.fr - SmartEiffel@loria.fr
 -- ------------------------------------------------------------------------------------------------------------
 */
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 /* macro read is used of read_stdin */
 
 int io_copy (char*source, char*target) {

--- a/sys/plugins/io/c/io.h
+++ b/sys/plugins/io/c/io.h
@@ -48,7 +48,7 @@
 #define io_fseek(f, o) (fseek((FILE*)(f),(o),SEEK_SET))
 #define io_ftell(f) ((EIF_INTEGER_64)ftell((FILE*)(f)))
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 #  define read_stdin(b, s) (read(STDIN_FILENO, b, s))
 #else
    extern int read_stdin(EIF_CHARACTER *buffer, int size);

--- a/sys/plugins/io/io_termios/c/io_termios.h
+++ b/sys/plugins/io/io_termios/c/io_termios.h
@@ -22,11 +22,11 @@
 -- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 -- THE SOFTWARE.
 */
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
  #include <termios.h>
 #endif
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
  #define termios_fd(FILE_p) fileno(FILE_p)
  #define termios_tcdrain(FILE_p) ((tcdrain(termios_fd(FILE_p))) == 0 ? 0 : errno)
  #define termios_cfgetispeed(s_termios) (cfgetispeed(s_termios))

--- a/sys/plugins/net/c/net.c
+++ b/sys/plugins/net/c/net.c
@@ -93,7 +93,7 @@ static void set_host_error(char* host) {
 /* ---------------------------------------------------------------------- */
 /* Initialization */
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 #define init() (1)
 
@@ -276,7 +276,7 @@ SOCKET net_udp(int a, int b, int c, int d, int port, EIF_BOOLEAN sync) {
   return result;
 }
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 SOCKET net_local(int port, EIF_BOOLEAN sync) {
   SOCKET result = INVALID_SOCKET;
@@ -353,7 +353,7 @@ SOCKET net_udp_socket(EIF_BOOLEAN sync) {
   return result;
 }
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 SOCKET net_local_socket(EIF_BOOLEAN sync) {
   SOCKET result = INVALID_SOCKET;
@@ -415,7 +415,7 @@ SOCKET net_udp_server(int port, EIF_BOOLEAN sync) {
   return result;
 }
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 SOCKET net_local_server(int port, EIF_BOOLEAN sync) {
   SOCKET result = INVALID_SOCKET;
   if (init()) {

--- a/sys/plugins/net/c/net.h
+++ b/sys/plugins/net/c/net.h
@@ -26,7 +26,7 @@
 -- ------------------------------------------------------------------------------------------------------------
 */
 
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 
 /*#  include <sys/types.h> done in base.h */
 #include <sys/socket.h>

--- a/sys/runtime/c/base.h
+++ b/sys/runtime/c/base.h
@@ -61,7 +61,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE
+#if defined __USE_POSIX || defined __unix__ || defined _POSIX_C_SOURCE || (defined __APPLE__ && defined __MACH__)
 #  include <unistd.h>
 #endif
 #if !defined(WIN32) && \

--- a/work/tools.sh
+++ b/work/tools.sh
@@ -68,13 +68,16 @@ case `uname -s` in
     Darwin)
 	flavor=Darwin
 	jobs=$((1 + $(sysctl -n hw.physicalcpu)))
+	# using boehm-gc from homebrew
+	PKG_INC=/opt/homebrew/include
+	PKG_LIBS=/opt/homebrew/lib
 	CC_TYPE=${CC_TYPE:-gcc}
 	CC=${CC:-$CC_TYPE}
-	CFLAGS="-pipe"
+	CFLAGS="-pipe -I${PKG_INC}"
 	CXX_TYPE=${CXX_TYPE:-g++}
 	CXX=${CXX:-${CXX_TYPE}}
-	CXXFLAGS="-pipe"
-	LDFLAGS=""
+	CXXFLAGS="-pipe -I${PKG_INC}"
+	LDFLAGS="-L${PKG_LIBS}"
 	germ_cc=${CC}
 	germ_cflags="-pipe -O2 -c -x c"
 	;;


### PR DESCRIPTION
macOS is compliant with POSIX. But  __USE_POSIX and _POSIX_C_SOURCE (and __unix__) are not defined in macOS.
So added condition (defined __APPLE__ && defined __MACH__) to determine that OS is macOS.

boehm-gc can be installed using Homebrew. Added compiler flags for such case.