### PR TITLE
fix compile bug

### DIFF
--- a/src/smarteiffel/commands/compile.e
+++ b/src/smarteiffel/commands/compile.e
@@ -143,7 +143,6 @@ feature {}
             not ace.has_root
          loop
             do_compile
-            ace.next_root
          end
          if ace.clean then
             from


### PR DESCRIPTION
 "install.sh" does not succeed on macOS even if #178 patch is patched. "compile" fails with signal 11 like this:


>  (snipped)
>  Application crash at run time.
>  No trace when commpiled using option "-boost"
>  Received signal 11 in '../compile'.
>  ../compile failed with status 1
>  Please look at Liberty/target/log/install-20231118-123818.log
>  ~~~~ se_make.sh ~~~~
>  ~~~~ done. ~~~~  

By this patch "install.sh" succeeds except "eiffeltest_server". (Maybe this is the same situation as FreeBSD.)
