### PR TITLE
eiffeldoc output readable without JS

### DIFF
--- a/resources/eiffeldoc/eiffeldoc.css
+++ b/resources/eiffeldoc/eiffeldoc.css
@@ -879,3 +879,7 @@ ul.menu > li > a:hover {
 .obsolete_mark {
     font-style: italic;
 }
+
+.expand_block_hidden {
+    display: none;
+}

--- a/resources/eiffeldoc/eiffeldoc.js
+++ b/resources/eiffeldoc/eiffeldoc.js
@@ -16,16 +16,12 @@ var cls_hidden = 'expand_block_hidden';
 
 function alter_display_by_id (id, value) {
     var el = document.getElementById (id + '_expanded');
-    var show = true;
-    if (el) {
-        if (value == 'none') {
-            show = false;
-        } else if (value == 'block') {
-            show = true;
-        } else {
-            show = el.classList.contains (cls_hidden);
-        }
+    var show = value;
+    if (value == 'toggle') {
+        show = el.classList.contains (cls_hidden);
+    }
 
+    if (el) {
         el.classList[show ? 'remove' : 'add'] (cls_hidden);
 
         var el_exp = document.getElementById (id + '_hl');
@@ -46,7 +42,7 @@ function href_class_link (el) {
 
 function href_feature_link (el) {
 	href_clicked = true;
-	alter_display_by_id ('id.' + el.href.substring (el.href.lastIndexOf ('#') + 1) + '.', 'block');
+	alter_display_by_id ('id.' + el.href.substring (el.href.lastIndexOf ('#') + 1) + '.', true);
 	return true;
 }
 

--- a/resources/eiffeldoc/eiffeldoc.js
+++ b/resources/eiffeldoc/eiffeldoc.js
@@ -12,10 +12,11 @@ function set_pov (clazz) {
     }
 }
 
+var cls_hidden = 'expand_block_hidden';
+
 function alter_display_by_id (id, value) {
     var el = document.getElementById (id + '_expanded');
     var show = true;
-    var cls_hidden = 'expand_block_hidden';
     if (el) {
         if (value == 'none') {
             show = false;
@@ -104,7 +105,7 @@ function init () {
 			if (e_exp) {
 				var e_hl = document.getElementById (el.id + '_hl');
 				if (e_hl) {
-					if (e_exp.style.display == 'none')
+					if (e_exp.classList.contains (cls_hidden))
 						e_hl.innerHTML = '+';
 					else
 						e_hl.innerHTML = '-';

--- a/resources/eiffeldoc/eiffeldoc.js
+++ b/resources/eiffeldoc/eiffeldoc.js
@@ -13,24 +13,26 @@ function set_pov (clazz) {
 }
 
 function alter_display_by_id (id, value) {
-	var el = document.getElementById (id + '_expanded');
-	if (el) {
-		if (value == 'none' || value == 'block')
-			el.style.display = value;
-		else if (el.style.display == 'none')
-			el.style.display = 'block';
-		else
-			el.style.display = 'none';
+    var el = document.getElementById (id + '_expanded');
+    var show = true;
+    var cls_hidden = 'expand_block_hidden';
+    if (el) {
+        if (value == 'none') {
+            show = false;
+        } else if (value == 'block') {
+            show = true;
+        } else {
+            show = el.classList.contains (cls_hidden);
+        }
 
-		var el_exp = document.getElementById (id + '_hl');
-		if (el_exp) {
-			if (el.style.display == 'none')
-				el_exp.innerHTML = '+';
-			else
-				el_exp.innerHTML = '-';
-		}
-	}
-	return true;
+        el.classList[show ? 'remove' : 'add'] (cls_hidden);
+
+        var el_exp = document.getElementById (id + '_hl');
+        if (el_exp) {
+            el_exp.innerHTML = show ? '-' : '+';
+        }
+    }
+    return true;
 }
 
 var href_clicked = false;

--- a/src/lib/html/html_output_stream.e
+++ b/src/lib/html/html_output_stream.e
@@ -353,6 +353,40 @@ feature {ANY} -- Header tags
          reset_state(state_in_script)
       end
 
+   open_noscript
+      require
+         in_header or in_body
+      do
+         indent
+         open_tag(os_noscript)
+         set_state(state_in_noscript)
+      end
+
+   close_noscript
+      require
+         in_noscript
+      do
+         close_tag(os_noscript)
+         reset_state(state_in_noscript)
+      end
+
+   open_style
+      require
+         in_header
+      do
+         indent
+         open_tag(os_style)
+         set_state(state_in_style)
+      end
+
+   close_style
+      require
+         in_style
+      do
+         close_tag(os_style)
+         reset_state(state_in_style)
+      end
+
 feature {ANY} -- Frames
    open_frameset
       require
@@ -1117,6 +1151,16 @@ feature {ANY} -- State queries
          Result := state = state_in_script
       end
 
+   in_noscript: BOOLEAN
+      do
+         Result := state = state_in_noscript
+      end
+
+   in_style: BOOLEAN
+      do
+         Result := state = state_in_style
+      end
+
    in_body: BOOLEAN
       do
          Result := state = state_in_body
@@ -1259,6 +1303,10 @@ feature {} -- States
    state_in_header: INTEGER 10
 
    state_in_script: INTEGER 11
+
+   state_in_noscript: INTEGER 12
+
+   state_in_style: INTEGER 13
 
    state_in_body: INTEGER 20
 
@@ -1452,6 +1500,10 @@ feature {} -- Once strings
    os_javascript: STRING "javascript"
 
    os_script: STRING "script"
+
+   os_noscript: STRING "noscript"
+
+   os_style: STRING "style"
 
    os_h1: STRING "h1"
 

--- a/src/smarteiffel/generation/eiffeldoc/eiffeldoc_globals.e
+++ b/src/smarteiffel/generation/eiffeldoc/eiffeldoc_globals.e
@@ -5,7 +5,6 @@ deferred class EIFFELDOC_GLOBALS
 
 insert
    GLOBALS
-   HTML_HANDLER
 
 feature {}
    operator_filter: HASHED_DICTIONARY[STRING, CHARACTER]
@@ -234,11 +233,11 @@ feature {}
          html_os.close_title
          html_os.put_stylesheet(css)
          html_os.put_javascript(js)
-         html_os.open_tag(once "noscript")
-         html_os.open_tag(once "style")
+         html_os.open_noscript
+         html_os.open_style
          html_os.put_string(once ".expand_block_hidden { display: block; }")
-         html_os.close_tag(once "style")
-         html_os.close_tag(once "noscript")
+         html_os.close_style
+         html_os.close_noscript
          html_os.with_attribute(once "onload", once "init()")
       ensure
          html_os.in_header

--- a/src/smarteiffel/generation/eiffeldoc/eiffeldoc_globals.e
+++ b/src/smarteiffel/generation/eiffeldoc/eiffeldoc_globals.e
@@ -5,6 +5,7 @@ deferred class EIFFELDOC_GLOBALS
 
 insert
    GLOBALS
+   HTML_HANDLER
 
 feature {}
    operator_filter: HASHED_DICTIONARY[STRING, CHARACTER]
@@ -233,6 +234,11 @@ feature {}
          html_os.close_title
          html_os.put_stylesheet(css)
          html_os.put_javascript(js)
+         html_os.open_tag(once "noscript")
+         html_os.open_tag(once "style")
+         html_os.put_string(once ".expand_block_hidden { display: block; }")
+         html_os.close_tag(once "style")
+         html_os.close_tag(once "noscript")
          html_os.with_attribute(once "onload", once "init()")
       ensure
          html_os.in_header
@@ -334,7 +340,7 @@ feature {}
          css_base_class /= Void
          base_id /= Void
       local
-         id: STRING
+         css_class, id: STRING
       do
          id := once ""
          id.clear_count
@@ -342,12 +348,11 @@ feature {}
          id.add_last('.')
 
          set_suffixed_attribute(once "id", filtered_attribute(id), once "_expanded", html_os)
-         set_suffixed_attribute(once "class", css_base_class, css_expanded_suffix, html_os)
-         if expand then
-            html_os.with_attribute(once "style", once "display: block")
-         else
-            html_os.with_attribute(once "style", once "display: none")
+         css_class := css_base_class
+         if not expand then
+            css_class := "expand_block_hidden " + css_base_class
          end
+         set_suffixed_attribute(once "class", css_class, css_expanded_suffix, html_os)
          html_os.open_div
       end
 

--- a/src/smarteiffel/generation/eiffeldoc/eiffeldoc_options.e
+++ b/src/smarteiffel/generation/eiffeldoc/eiffeldoc_options.e
@@ -119,9 +119,8 @@ feature {EIFFELDOC, EIFFELDOC_SHORTER, EIFFELDOC_SHORTER_SOURCEDOC, EIFFELDOC_SH
          html.close_div
          html.close_div
          html.close_div
-         html.with_attribute(once "class", once "points_of_view_expanded")
+         html.with_attribute(once "class", once "points_of_view_expanded expand_block_hidden")
          html.with_attribute(once "id", once "points_of_view.is_expanded")
-         html.with_attribute(once "style", once "display: none")
          html.open_div
          html.with_attribute(once "class", once "class_link")
          html.open_list


### PR DESCRIPTION
This PR addresses https://savannah.gnu.org/bugs/?48153

- collapsing the expandable blocks is handled using a CSS class instead of inline `display: none;` styles
- there's a stylesheet in a `<noscript>` tag making sure that the class takes no effect when JS is not available

For now I submit a minimal working set of changes as a POC. If it passes a review, there are a few known issues which I should probably address before it gets merged.