### PR TITLE
-profile does not work on macOS

### DIFF
--- a/src/smarteiffel/kernel/system_tools.e
+++ b/src/smarteiffel/kernel/system_tools.e
@@ -883,7 +883,7 @@ feature {C_PRETTY_PRINTER}
 
    add_lib_profile
       once
-         if system_name = unix_system then
+         if system_name = unix_system and then not system_flavor.is_equal("Darwin") then
             add_external_lib("rt")
          end
       end


### PR DESCRIPTION
-profile does not work on macOS because rt library does not exist on macOS.
I removed -lrt from *.make, then compile succeeded.

This patch may not be a good one, since it is written as a string literal. I would be happy you use it as a reference.