### PR TITLE
to compile eiffeltest_* on FreeBSD and macOS

### DIFF
--- a/src/lib/i18n/externals/plugin/c/libs
+++ b/src/lib/i18n/externals/plugin/c/libs
@@ -1,2 +1,6 @@
 [UNIX.Cygwin]
 intl: intl
+[UNIX.Darwin]
+intl: intl
+[UNIX.FreeBSD]
+intl: intl


### PR DESCRIPTION
Sorry for pulling request to GitHub, not to savannah.

All tools controlled by "se" would become compilable on FreeBSD and macOS by applying this patch.
However, I have not verified that the newly generated two binaries (eiffeltest_ng and eiffeltest_server) are working correctly.