### PR TITLE
patches for NetBSD 10

### DIFF
--- a/src/lib/i18n/externals/plugin/c/libs
+++ b/src/lib/i18n/externals/plugin/c/libs
@@ -1,2 +1,4 @@
 [UNIX.Cygwin]
 intl: intl
+[UNIX.NetBSD]
+intl: intl

--- a/work/tools.sh
+++ b/work/tools.sh
@@ -34,7 +34,7 @@ case `uname -s` in
     NetBSD)
 	export PATH=/usr/pkg/bin:$PATH
 	flavor=NetBSD
-	jobs=$((1 + $(grep '^processor' /proc/cpuinfo|wc -l)))
+	jobs=$((1 + $(grep -a '^processor' /proc/cpuinfo|wc -l)))
 	CC_TYPE=${CC_TYPE:-gcc}
 	CC=${CC:-$CC_TYPE}
 	# using boehm-gc from pkgsrc


### PR DESCRIPTION
[UNIX.NetBSD]:
 needed to build eiffeltest_server
grep's -a option:
 needed because grep misinterprets /proc/cpuinfo as a binary file. (original works but the number of cpu is treated  as 1)