### PR TITLE
fix ncurses bug

### DIFF
--- a/sys/plugins/ncurses/c/ncurses.c
+++ b/sys/plugins/ncurses/c/ncurses.c
@@ -66,14 +66,14 @@ void init_screen(void) {
 int wgetwidth(void* win) {
    int x, y;
    getmaxyx((WINDOW*)win, y, x);
-   return x - wgetleft(win);
+   return x;
 }
 
 
 int wgetheight(void* win) {
    int x, y;
    getmaxyx((WINDOW*)win, y, x);
-   return y - wgettop(win);
+   return y;
 }
 
 


### PR DESCRIPTION
Most of  programs in tutorial/ncurses do not work correctly when they are compiled with no option. Some of them work correctly if they are compiled with -boost option. (Sorry, I have not confirmed other options.)

According to "man getmaxyx",  "Like getyx, the getbegyx and getmaxyx macros store the current beginning coordinates and size of the specified window." So I think the current implementation of wgetwidth and wgetheight are wrong.

Platform: FreeBSD(GhostBSD), macOS