### PR TITLE
net/cgi: new class CGI_SIMPLE_HANDLER

### DIFF
--- a/src/lib/net/cgi/cgi_simple_handler.e
+++ b/src/lib/net/cgi/cgi_simple_handler.e
@@ -1,0 +1,51 @@
+-- This file is part of a Liberty Eiffel library.
+-- See the full copyright at the end.
+--
+-- See the Copyright notice at the end of this file.
+--
+deferred class CGI_SIMPLE_HANDLER
+   --
+   -- Single-entrypoint alternative to CGI_HANDLER.
+   --
+
+inherit
+   CGI_HANDLER
+      rename
+         get as handle
+         post as handle
+         head as handle
+         delete as handle
+         put as handle
+      end
+
+feature {CGI_REQUEST_METHOD}
+   handle
+      deferred
+      end
+
+   invoke_method (a_method: FIXED_STRING)
+      do
+         handle
+      end
+
+end -- class CGI_HANDLER
+--
+-- Copyright (C) 2009-2022: by all the people cited in the AUTHORS file.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.


### PR DESCRIPTION
I find the separate entrypoints for each HTTP request method rather unpractical. Let there be an alternative handler with just a single method to implement.