### PR TITLE
1 / 3 causes "require assertion violation"

### DIFF
--- a/src/lib/numeric/numeric.e
+++ b/src/lib/numeric/numeric.e
@@ -30,7 +30,6 @@ feature {ANY}
       require
          other /= Void
          other /= zero
-         divisible(other)
       deferred
       end
 


### PR DESCRIPTION
The following sample program causes "require assertion violation" when it is compiled with no option.
(With -boost option it runs successfully.)
~~~
class DIV

create {ANY}
   make

feature {ANY}
   make
      local
         i, j: INTEGER_8
      do
         i := 1
         j := 3
         std_output.put_string((i / j).to_string + "%N")
      end

end -- class DIV
~~~