### PR TITLE
fix exception test 13

### DIFF
--- a/test/language/exceptions/test_exceptions13.e
+++ b/test/language/exceptions/test_exceptions13.e
@@ -13,7 +13,7 @@ create {}
 feature {ANY}
    make
       do
-         assert(signal_numer = 0)
+         assert(signal_number = 0)
       end
 
 end -- class TEST_EXCEPTIONS13


### PR DESCRIPTION
test_exceptions13.e has not compiled due to a typo in a variable name.

(It is not a program to test that it cannot be compiled, I think.)