### PR TITLE
fix a minor bug in example of cli

### DIFF
--- a/tutorial/cli/example1.e
+++ b/tutorial/cli/example1.e
@@ -22,6 +22,7 @@ feature {ANY}
 
          if opt_organization.is_set then
             io.put_string(opt_organization.item)
+            io.put_character(' ')
          else
             io.put_string(opt_author_last.item.as_upper)
             io.put_string(", ")


### PR DESCRIPTION
There should be a space between the organization name and the title.

~~~
$ ./example1 -o some_org some_title 2024
some_orgsome_title. 2024
~~~